### PR TITLE
fix: non-specified region languages not redirecting

### DIFF
--- a/frontend/next-i18next.config.js
+++ b/frontend/next-i18next.config.js
@@ -4,6 +4,7 @@ module.exports = {
     i18n: {
         defaultLocale: "en-US",
         locales: ["en-US", "es-ES", "fr-FR", "zh-CN"],
+        nonExplicitSupportedLngs: true
     },
 
     localePath: typeof window === "undefined" ? require("path").resolve("./lang") : '/lang',

--- a/frontend/next-i18next.config.js
+++ b/frontend/next-i18next.config.js
@@ -4,6 +4,12 @@ module.exports = {
     i18n: {
         defaultLocale: "en-US",
         locales: ["en-US", "es-ES", "fr-FR", "zh-CN"],
+        fallbackLng: {
+            default: ["en"],
+            'es': ["es-ES"],
+            'fr': ["fr-FR"],
+            'zh': ["zh-CN"]
+        },
         nonExplicitSupportedLngs: true
     },
 


### PR DESCRIPTION
Browsers with non-specified region languages weren't redirecting to languages that had regions that were supported.

closes #27